### PR TITLE
Name the spoke kubernetes-auth role k8s-<cluster>-<vs>

### DIFF
--- a/apis/kubevault/v1alpha2/vaultserver_helpers.go
+++ b/apis/kubevault/v1alpha2/vaultserver_helpers.go
@@ -125,7 +125,7 @@ func (v VaultServer) PolicyNameForSpoke(cluster string) string {
 // VaultRoleNameForSpoke is the Vault kubernetes-auth role bound to the spoke's
 // hub ServiceAccount; referenced by the spoke AppBinding parameters.vaultRole.
 func (v VaultServer) VaultRoleNameForSpoke(cluster string) string {
-	return fmt.Sprintf("spoke-%s-%s", cluster, v.Name)
+	return fmt.Sprintf("k8s-%s-%s", cluster, v.Name)
 }
 
 // SpokeAgentNamespace is the namespace on the managed cluster where the


### PR DESCRIPTION
`VaultServer.VaultRoleNameForSpoke` now returns `k8s-<cluster>-<vs>` instead of `spoke-<cluster>-<vs>`.

This aligns the spoke's kubernetes-auth role name with the `k8s.<cluster>` mount-path prefix the per-spoke policy already scopes to. The role name is referenced as an exact path in the policy document (`auth/kubernetes/role/<name>`, no wildcard), so the change is cosmetic and carries no prefix-collision risk.

Consumed by the operator's spoke-agent placement controller (policy document, VaultPolicyBinding role name, and the spoke AppBinding `parameters.vaultRole`), all of which derive from this one helper.