### PR TITLE
Add role pod label constants

### DIFF
--- a/apis/constants.go
+++ b/apis/constants.go
@@ -122,6 +122,21 @@ const (
 )
 
 const (
+	// VaultPodRoleLabelKey is maintained by the operator on every vault pod and
+	// reflects the node's HA role as reported by /v1/sys/health. The
+	// client-facing vault Service selects role=primary for raft-backed servers
+	// so client traffic (and the spoke gRPC proxy) always lands on the raft
+	// leader instead of round-robining across standbys.
+	VaultPodRoleLabelKey = "kubevault.com/role"
+
+	// VaultPodRolePrimary marks the unsealed active (leader) node.
+	VaultPodRolePrimary = "primary"
+
+	// VaultPodRoleStandby marks unsealed standby nodes.
+	VaultPodRoleStandby = "standby"
+)
+
+const (
 	ResourceKindStatefulSet = "StatefulSet"
 )
 


### PR DESCRIPTION
Adds the pod label constants for raft leader Service routing.

kubevault.com/role (primary|standby) is maintained by each vault pod's unsealer sidecar from the local /v1/sys/health. The client Service selects role=primary for raft-backed servers so traffic follows the raft leader.

This is the base of the raft-leader routing feature: the vendored constants are consumed by the unsealer (which sets the label) and the operator (which reconciles it and wires the Service selector).