### PR TITLE
Remove VaultRelay.spec.image; resolve it from the hub AppBinding's spec.version

### DIFF
--- a/.config/api-rules/violation_exceptions.list
+++ b/.config/api-rules/violation_exceptions.list
@@ -47,7 +47,6 @@ API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,PodSpec,V
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,ExternalIPs
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,LoadBalancerSourceRanges
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,Ports
-API rule violation: list_type_missing,kubevault.dev/apimachinery/apis/ops/v1alpha1,VaultOpsRequestStatus,Conditions
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI
 API rule violation: names_match,k8s.io/api/core/v1,ContainerStatus,LastTerminationState
 API rule violation: names_match,k8s.io/api/core/v1,DaemonEndpoint,Port

--- a/apis/kubevault/v1alpha2/openapi_generated.go
+++ b/apis/kubevault/v1alpha2/openapi_generated.go
@@ -25749,13 +25749,6 @@ func schema_apimachinery_apis_kubevault_v1alpha2_VaultRelaySpec(ref common.Refer
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
-					"image": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Image is the spoke-relay container image",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"tls": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TLS configuration for gRPC connection",
@@ -25901,13 +25894,6 @@ func schema_apimachinery_apis_kubevault_v1alpha2_VaultRelayTemplate(ref common.R
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Namespace on the managed cluster where the VaultRelay and its companion resources are created. Defaults to the VaultServer's namespace.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"image": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Image overrides the spoke-relay container image.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/apis/kubevault/v1alpha2/vault_relay_helpers.go
+++ b/apis/kubevault/v1alpha2/vault_relay_helpers.go
@@ -80,14 +80,6 @@ func (vr VaultRelay) GetGRPCPort() int32 {
 	return vr.Spec.HubVaultRef.GRPCPort
 }
 
-// GetImage returns the configured spoke-relay image, falling back to image.
-func (vr VaultRelay) GetImage(image string) string {
-	if vr.Spec.Image == "" {
-		return image
-	}
-	return vr.Spec.Image
-}
-
 // SetDefaults sets default values for VaultRelay
 func (vr *VaultRelay) SetDefaults() {
 	if vr.Spec.HubVaultRef.GRPCPort == 0 {

--- a/apis/kubevault/v1alpha2/vault_relay_types.go
+++ b/apis/kubevault/v1alpha2/vault_relay_types.go
@@ -67,10 +67,6 @@ type VaultRelaySpec struct {
 	// +optional
 	TokenSecretRef *core.LocalObjectReference `json:"tokenSecretRef,omitempty"`
 
-	// Image is the spoke-relay container image
-	// +optional
-	Image string `json:"image,omitempty"`
-
 	// TLS configuration for gRPC connection
 	// +optional
 	TLS *VaultRelayTLSConfig `json:"tls,omitempty"`

--- a/apis/kubevault/v1alpha2/vaultserver_types.go
+++ b/apis/kubevault/v1alpha2/vaultserver_types.go
@@ -189,10 +189,6 @@ type VaultRelayTemplate struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
-	// Image overrides the spoke-relay container image.
-	// +optional
-	Image string `json:"image,omitempty"`
-
 	// PodTemplate is an optional configuration for the spoke-relay pods.
 	// +optional
 	PodTemplate ofst.PodTemplateSpec `json:"podTemplate,omitempty"`

--- a/crds/kubevault.com_vaultrelays.yaml
+++ b/crds/kubevault.com_vaultrelays.yaml
@@ -110,9 +110,6 @@ spec:
                 - name
                 - namespace
                 type: object
-              image:
-                description: Image is the spoke-relay container image
-                type: string
               isolateTenants:
                 description: |-
                   IsolateTenants opts this spoke into per-tenant OpenBao namespace isolation against

--- a/crds/kubevault.com_vaultservers.yaml
+++ b/crds/kubevault.com_vaultservers.yaml
@@ -21252,9 +21252,6 @@ spec:
                       BootstrapTokenTTL controls the TTL of hub bootstrap tokens minted per spoke
                       (and therefore their rotation period). Default 24h, minimum 1h.
                     type: string
-                  image:
-                    description: Image overrides the spoke-relay container image.
-                    type: string
                   namespace:
                     description: |-
                       Namespace on the managed cluster where the VaultRelay and its companion


### PR DESCRIPTION
## Summary
- `VaultRelay` no longer has a `spec.image` field. The spoke-relay controller (operator repo) resolves its container image by reading `spec.version` off the AppBinding that fronts the hub vault and looking up the matching `VaultServerVersion.spec.vault.image`, so the relay always tracks the hub Vault it talks to.
- Removed the now-meaningless `Image` override from `VaultServer.spec.relayTemplate` (`VaultRelayTemplate`).
- CRD yaml and generated openapi updated to match (scalar-only removals, no deepcopy/conversion regen needed).

## Test plan
- [x] `go build ./...`
- [ ] Companion operator PR (kubevault/operator) vendors this commit and updates the VaultRelay/SpokeRelay controllers + tests accordingly