### PR TITLE
Add Sigilr as an OpenBao-derivative Vault distro

### DIFF
--- a/.config/api-rules/violation_exceptions.list
+++ b/.config/api-rules/violation_exceptions.list
@@ -47,6 +47,7 @@ API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,PodSpec,V
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,ExternalIPs
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,LoadBalancerSourceRanges
 API rule violation: list_type_missing,kmodules.xyz/offshoot-api/api/v1,ServiceSpec,Ports
+API rule violation: list_type_missing,kubevault.dev/apimachinery/apis/ops/v1alpha1,VaultOpsRequestStatus,Conditions
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI
 API rule violation: names_match,k8s.io/api/core/v1,ContainerStatus,LastTerminationState
 API rule violation: names_match,k8s.io/api/core/v1,DaemonEndpoint,Port

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16569,10 +16569,6 @@
           "description": "BootstrapTokenTTL controls the TTL of hub bootstrap tokens minted per spoke (and therefore their rotation period). Default 24h, minimum 1h.",
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Duration"
         },
-        "image": {
-          "description": "Image overrides the spoke-relay container image.",
-          "type": "string"
-        },
         "namespace": {
           "description": "Namespace on the managed cluster where the VaultRelay and its companion resources are created. Defaults to the VaultServer's namespace.",
           "type": "string"

--- a/apis/catalog/v1alpha1/vaultserver_version_helpers.go
+++ b/apis/catalog/v1alpha1/vaultserver_version_helpers.go
@@ -29,3 +29,7 @@ func (v VaultServerVersion) CustomResourceDefinition() *apiextensions.CustomReso
 func (v VaultServerVersion) GetKey() string {
 	return v.Name
 }
+
+func (d Distro) IsOpenBaoDerivative() bool {
+	return d == DistroOpenBao || d == DistroSigilr
+}

--- a/apis/catalog/v1alpha1/vaultserver_version_types.go
+++ b/apis/catalog/v1alpha1/vaultserver_version_types.go
@@ -71,12 +71,13 @@ type VaultServerVersionSpec struct {
 	Stash appcat.StashAddonSpec `json:"stash,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Vault;OpenBao
+// +kubebuilder:validation:Enum=Vault;OpenBao;Sigilr
 type Distro string
 
 const (
 	DistroOfficial Distro = "Vault"
 	DistroOpenBao  Distro = "OpenBao"
+	DistroSigilr   Distro = "Sigilr"
 )
 
 // VaultServerVersionVault is the vault image

--- a/crds/catalog.kubevault.com_vaultserverversions.yaml
+++ b/crds/catalog.kubevault.com_vaultserverversions.yaml
@@ -65,6 +65,7 @@ spec:
                 enum:
                 - Vault
                 - OpenBao
+                - Sigilr
                 type: string
               exporter:
                 description: Exporter Image


### PR DESCRIPTION
## Summary
- Add `Sigilr` as a valid `Distro` value in the `VaultServerVersion` catalog API (alongside `Vault` and `OpenBao`).
- Add `Distro.IsOpenBaoDerivative()` helper returning `true` for both `OpenBao` and `Sigilr`, so downstream OpenBao-specific logic can be reused for Sigilr without special-casing.
- Regenerate CRDs, swagger spec, and API-rule violation exceptions (`make gen`).