### PR TITLE
engine/v1alpha1: fix RabbitMQ connection_uri field + add mutual-TLS support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14383,7 +14383,7 @@
       }
     },
     "dev.kubevault.apimachinery.apis.engine.v1alpha1.RabbitMQConfiguration": {
-      "description": "RabbitMQConfiguration defines a RabbitMQ app configuration. The OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions credentials via the RabbitMQ Management HTTP API (using rabbit-hole/v3), so the connection payload uses `connection_url` (the RabbitMQ management HTTP base URL, e.g. `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth (username + password from the AppBinding secret). RabbitMQ is dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation is the plugin's default DELETE /api/users/\u003cname\u003e (idempotent) so no `revocation_statements` field is exposed here. https://www.rabbitmq.com/access-control.html",
+      "description": "RabbitMQConfiguration defines a RabbitMQ app configuration. The OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions credentials via the RabbitMQ Management HTTP API (using rabbit-hole/v3), so the connection payload uses `connection_uri` (the RabbitMQ management HTTP base URL, e.g. `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth (username + password from the AppBinding secret). RabbitMQ is dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation is the plugin's default DELETE /api/users/\u003cname\u003e (idempotent) so no `revocation_statements` field is exposed here.\n\nTLS: if the referenced AppBinding's `spec.clientConfig.caBundle` is set, its PEM content is forwarded as the plugin's `tls_ca` (server certificate verification). `ClientCert`/`ClientKey` are optional and enable mutual TLS against the management API. https://www.rabbitmq.com/access-control.html",
       "type": "object",
       "required": [
         "databaseRef"
@@ -14397,8 +14397,16 @@
             "default": ""
           }
         },
+        "clientCert": {
+          "description": "ClientCert is a PEM-encoded client certificate (not a file path) presented to the RabbitMQ management API for mutual TLS. Requires ClientKey to also be set.",
+          "type": "string"
+        },
+        "clientKey": {
+          "description": "ClientKey is the PEM-encoded private key (not a file path) corresponding to ClientCert.",
+          "type": "string"
+        },
         "databaseRef": {
-          "description": "Specifies the RabbitMQ database appbinding reference. The AppBinding URL points at the RabbitMQ Management HTTP base URL (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes username/password used to authenticate against the management API when the plugin issues credential operations.",
+          "description": "Specifies the RabbitMQ database appbinding reference. The AppBinding URL points at the RabbitMQ Management HTTP base URL (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes username/password used to authenticate against the management API when the plugin issues credential operations. If `spec.clientConfig.caBundle` is set, its PEM content is used to verify the management API's server certificate.",
           "default": {},
           "$ref": "#/definitions/xyz.kmodules.custom-resources.apis.appcatalog.v1alpha1.AppReference"
         },

--- a/apis/engine/v1alpha1/openapi_generated.go
+++ b/apis/engine/v1alpha1/openapi_generated.go
@@ -28479,12 +28479,12 @@ func schema_apimachinery_apis_engine_v1alpha1_RabbitMQConfiguration(ref common.R
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RabbitMQConfiguration defines a RabbitMQ app configuration. The OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions credentials via the RabbitMQ Management HTTP API (using rabbit-hole/v3), so the connection payload uses `connection_url` (the RabbitMQ management HTTP base URL, e.g. `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth (username + password from the AppBinding secret). RabbitMQ is dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation is the plugin's default DELETE /api/users/<name> (idempotent) so no `revocation_statements` field is exposed here. https://www.rabbitmq.com/access-control.html",
+				Description: "RabbitMQConfiguration defines a RabbitMQ app configuration. The OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions credentials via the RabbitMQ Management HTTP API (using rabbit-hole/v3), so the connection payload uses `connection_uri` (the RabbitMQ management HTTP base URL, e.g. `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth (username + password from the AppBinding secret). RabbitMQ is dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation is the plugin's default DELETE /api/users/<name> (idempotent) so no `revocation_statements` field is exposed here.\n\nTLS: if the referenced AppBinding's `spec.clientConfig.caBundle` is set, its PEM content is forwarded as the plugin's `tls_ca` (server certificate verification). `ClientCert`/`ClientKey` are optional and enable mutual TLS against the management API. https://www.rabbitmq.com/access-control.html",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"databaseRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the RabbitMQ database appbinding reference. The AppBinding URL points at the RabbitMQ Management HTTP base URL (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes username/password used to authenticate against the management API when the plugin issues credential operations.",
+							Description: "Specifies the RabbitMQ database appbinding reference. The AppBinding URL points at the RabbitMQ Management HTTP base URL (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes username/password used to authenticate against the management API when the plugin issues credential operations. If `spec.clientConfig.caBundle` is set, its PEM content is used to verify the management API's server certificate.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppReference"),
 						},
@@ -28514,6 +28514,20 @@ func schema_apimachinery_apis_engine_v1alpha1_RabbitMQConfiguration(ref common.R
 					"passwordPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PasswordPolicy is the optional name of a Vault password policy that generates dynamic credentials.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"clientCert": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClientCert is a PEM-encoded client certificate (not a file path) presented to the RabbitMQ management API for mutual TLS. Requires ClientKey to also be set.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"clientKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ClientKey is the PEM-encoded private key (not a file path) corresponding to ClientCert.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/apis/engine/v1alpha1/rabbitmq_types.go
+++ b/apis/engine/v1alpha1/rabbitmq_types.go
@@ -89,20 +89,27 @@ type RabbitMQRoleList struct {
 // RabbitMQConfiguration defines a RabbitMQ app configuration. The
 // OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions
 // credentials via the RabbitMQ Management HTTP API (using
-// rabbit-hole/v3), so the connection payload uses `connection_url`
+// rabbit-hole/v3), so the connection payload uses `connection_uri`
 // (the RabbitMQ management HTTP base URL, e.g.
 // `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth
 // (username + password from the AppBinding secret). RabbitMQ is
 // dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation
 // is the plugin's default DELETE /api/users/<name> (idempotent) so no
 // `revocation_statements` field is exposed here.
+//
+// TLS: if the referenced AppBinding's `spec.clientConfig.caBundle` is
+// set, its PEM content is forwarded as the plugin's `tls_ca` (server
+// certificate verification). `ClientCert`/`ClientKey` are optional and
+// enable mutual TLS against the management API.
 // https://www.rabbitmq.com/access-control.html
 type RabbitMQConfiguration struct {
 	// Specifies the RabbitMQ database appbinding reference. The
 	// AppBinding URL points at the RabbitMQ Management HTTP base URL
 	// (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes
 	// username/password used to authenticate against the management
-	// API when the plugin issues credential operations.
+	// API when the plugin issues credential operations. If
+	// `spec.clientConfig.caBundle` is set, its PEM content is used to
+	// verify the management API's server certificate.
 	DatabaseRef appcat.AppReference `json:"databaseRef"`
 
 	// Specifies the name of the plugin to use for this connection.
@@ -120,6 +127,17 @@ type RabbitMQConfiguration struct {
 	// generates dynamic credentials.
 	// +optional
 	PasswordPolicy string `json:"passwordPolicy,omitempty"`
+
+	// ClientCert is a PEM-encoded client certificate (not a file path)
+	// presented to the RabbitMQ management API for mutual TLS.
+	// Requires ClientKey to also be set.
+	// +optional
+	ClientCert string `json:"clientCert,omitempty"`
+
+	// ClientKey is the PEM-encoded private key (not a file path)
+	// corresponding to ClientCert.
+	// +optional
+	ClientKey string `json:"clientKey,omitempty"`
 
 	// Insecure disables TLS verification when talking to the RabbitMQ
 	// management endpoint. Useful for self-signed development

--- a/crds/engine.kubevault.com_secretengines.yaml
+++ b/crds/engine.kubevault.com_secretengines.yaml
@@ -1420,13 +1420,18 @@ spec:
                   RabbitMQConfiguration defines a RabbitMQ app configuration. The
                   OpenBao `rabbitmq-database-plugin` (sigilr/openbao#8) provisions
                   credentials via the RabbitMQ Management HTTP API (using
-                  rabbit-hole/v3), so the connection payload uses `connection_url`
+                  rabbit-hole/v3), so the connection payload uses `connection_uri`
                   (the RabbitMQ management HTTP base URL, e.g.
                   `http://rabbitmq.demo.svc:15672`). Authentication is HTTP Basic Auth
                   (username + password from the AppBinding secret). RabbitMQ is
                   dynamic: NewUser/UpdateUser/DeleteUser are all supported. Revocation
                   is the plugin's default DELETE /api/users/<name> (idempotent) so no
                   `revocation_statements` field is exposed here.
+
+                  TLS: if the referenced AppBinding's `spec.clientConfig.caBundle` is
+                  set, its PEM content is forwarded as the plugin's `tls_ca` (server
+                  certificate verification). `ClientCert`/`ClientKey` are optional and
+                  enable mutual TLS against the management API.
                   https://www.rabbitmq.com/access-control.html
                 properties:
                   allowedRoles:
@@ -1436,13 +1441,26 @@ spec:
                     items:
                       type: string
                     type: array
+                  clientCert:
+                    description: |-
+                      ClientCert is a PEM-encoded client certificate (not a file path)
+                      presented to the RabbitMQ management API for mutual TLS.
+                      Requires ClientKey to also be set.
+                    type: string
+                  clientKey:
+                    description: |-
+                      ClientKey is the PEM-encoded private key (not a file path)
+                      corresponding to ClientCert.
+                    type: string
                   databaseRef:
                     description: |-
                       Specifies the RabbitMQ database appbinding reference. The
                       AppBinding URL points at the RabbitMQ Management HTTP base URL
                       (e.g. `http://rabbitmq.demo.svc:15672`); the secret contributes
                       username/password used to authenticate against the management
-                      API when the plugin issues credential operations.
+                      API when the plugin issues credential operations. If
+                      `spec.clientConfig.caBundle` is set, its PEM content is used to
+                      verify the management API's server certificate.
                     properties:
                       name:
                         description: |-


### PR DESCRIPTION
## Summary

Follow-up to #151 (squash-merged before these two fixes landed on the PR branch):

1. **Bug fix**: the plugin's connection payload field is `connection_uri`, not `connection_url` (OpenBao `rabbitmq-database-plugin`, sigilr/openbao#8, hard-errors `Initialize` without it). Doc-comment-only fix; the JSON tag was never wrong, but the wrong name had propagated into the generated CRD description.
2. **Feature**: adds `ClientCert`/`ClientKey` (PEM content, not file paths) to `RabbitMQConfiguration` for mutual TLS against the RabbitMQ management API, mirroring `ElasticsearchConfiguration`. Server-certificate verification is sourced from the AppBinding's `spec.clientConfig.caBundle` (matching the existing Redis pattern), not a new field.

## Test plan
- [x] `go build ./...`, `go vet ./apis/engine/...`, `gofmt` clean
- [x] `make manifests` regenerated `crds/engine.kubevault.com_secretengines.yaml` — diff is scoped to the RabbitMQ section only
- [x] No deepcopy regen needed (plain string fields, already covered by the existing `*out = *in`)